### PR TITLE
LIBIIIF-153. Make the Image.MAX_IMAGE_PIXELS configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,17 @@ STORAGE_DIR=image_cache
 # storage directory layout
 # allowed values are "basic", "md5_encoded", and "md5_encoded_pairtree"
 STORAGE_LAYOUT=basic
+# maximum pixel size of an image;
+# default is 0, which lets PIL use its default;
+# set to a positive number to change the maximum size,
+# or set to a negative number to set no limit
+MAX_IMAGE_PIXELS=0 
 # enable debugging and hot reloading when run via "flask run"
 FLASK_DEBUG=1
 ```
+
+For further information about `MAX_IMAGE_PIXELS`, see the
+[PILLOW 5.0.0 Release Notes]
 
 ### Running
 
@@ -110,3 +118,4 @@ docker run -d -p 5000:5000 \
 
 [pyenv]: https://github.com/pyenv/pyenv
 [waitress]: https://pypi.org/project/waitress/
+[PILLOW 5.0.0 Release Notes]: https://github.com/python-pillow/Pillow/blob/fdbd719da4c77c7e23e2e9e9b71d0d177f2d3369/docs/releasenotes/5.0.0.rst#decompression-bombs-now-raise-exceptions

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ FLASK_DEBUG=1
 ```
 
 For further information about `MAX_IMAGE_PIXELS`, see the
-[PILLOW 5.0.0 Release Notes]
+[Pillow 5.0.0 Release Notes]
 
 ### Running
 
@@ -118,4 +118,4 @@ docker run -d -p 5000:5000 \
 
 [pyenv]: https://github.com/pyenv/pyenv
 [waitress]: https://pypi.org/project/waitress/
-[PILLOW 5.0.0 Release Notes]: https://github.com/python-pillow/Pillow/blob/fdbd719da4c77c7e23e2e9e9b71d0d177f2d3369/docs/releasenotes/5.0.0.rst#decompression-bombs-now-raise-exceptions
+[Pillow 5.0.0 Release Notes]: https://github.com/python-pillow/Pillow/blob/fdbd719da4c77c7e23e2e9e9b71d0d177f2d3369/docs/releasenotes/5.0.0.rst#decompression-bombs-now-raise-exceptions

--- a/src/mezcal/config.py
+++ b/src/mezcal/config.py
@@ -17,6 +17,7 @@ JWT_TOKEN = os.environ.get('JWT_TOKEN')
 REPO_BASE_URL = os.environ.get('REPO_BASE_URL')
 STORAGE_DIR = Path.cwd() / os.environ.get('STORAGE_DIR')
 STORAGE_LAYOUT = DirectoryLayout[os.environ.get('STORAGE_LAYOUT', 'BASIC').upper()]
+MAX_IMAGE_PIXELS = int(os.environ.get('MAX_IMAGE_PIXELS', 0))
 
 TIMER_LOG_FORMAT = 'Time to {name}: {milliseconds:.3f} ms'
 LOCK_TIMEOUT = 30

--- a/src/mezcal/storage.py
+++ b/src/mezcal/storage.py
@@ -8,9 +8,19 @@ from PIL import Image
 from codetiming import Timer
 from filelock import FileLock
 
-from mezcal.config import STORAGE_DIR, DirectoryLayout, STORAGE_LAYOUT, TIMER_LOG_FORMAT
+from mezcal.config import STORAGE_DIR, DirectoryLayout, STORAGE_LAYOUT, TIMER_LOG_FORMAT, MAX_IMAGE_PIXELS
 
 logger = logging.getLogger(__name__)
+
+# set a different max pixel size than the default
+# leave MAX_IMAGE_PIXELS at 0 to use the default
+if MAX_IMAGE_PIXELS > 0:
+    # positive numbers mean set a limit
+    Image.MAX_IMAGE_PIXELS = MAX_IMAGE_PIXELS
+elif MAX_IMAGE_PIXELS < 0:
+    # negative numbers mean no limit
+    logger.warning('MAX_IMAGE_PIXELS is set to "no limit". Only use with origin images from a trusted source.')
+    Image.MAX_IMAGE_PIXELS = None
 
 
 def get_local_dir(repo_path: Path | str, layout: DirectoryLayout = DirectoryLayout.BASIC) -> Path:


### PR DESCRIPTION
Must be able to set it to a larger value for some of our large images, in particular the Prange Posters collection. Issues a warning if it is set to "no limit".

https://issues.umd.edu/browse/LIBIIIF-153