### PR TITLE
LIBFCREPO-1552: Rotate image only if orientation other than 1 is found

### DIFF
--- a/src/mezcal/storage.py
+++ b/src/mezcal/storage.py
@@ -7,6 +7,7 @@ from struct import unpack
 from threading import current_thread
 
 from PIL import Image
+from PIL.ImageOps import exif_transpose
 from codetiming import Timer
 from filelock import FileLock
 
@@ -65,7 +66,6 @@ class LocalStorage:
 
 SUPPORTED_JPEG_MODES = ('L', 'RGB', 'CMYK')
 
-
 class MezzanineFile:
     def __init__(self, path: Path = None):
         self.path = path
@@ -92,6 +92,12 @@ class MezzanineFile:
             try:
                 img = Image.open(fh)
                 self.path.parent.mkdir(parents=True, exist_ok=True)
+
+                # Rotate the image according to it's EXIF Orientation Tag
+                orientation = img.getexif().get(0x0112)
+
+                if orientation is not None and orientation != 1:
+                    img = exif_transpose(img)
 
                 if img.mode not in SUPPORTED_JPEG_MODES:
                     logger.info(f'Source has mode "{img.mode}" that is not supported by JPEG; will attempt to convert')


### PR DESCRIPTION
Can't regularly call the method because the resulting copy, in cases where no rotation is needed, is not the same as the original.

https://umd-dit.atlassian.net/browse/LIBFCREPO-1552