### PR TITLE
LIBIIIF-217. Use plastron-client to connect to the repository.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ Create a `.env` file with the following contents:
 
 ```dotenv
 # authentication token for the origin repository
-MEZCAL_JWT_TOKEN=...
+MEZCAL_FCREPO_JWT_TOKEN=...
 # base URL to the origin repository
-MEZCAL_REPO_BASE_URL=...
+MEZCAL_FCREPO_ENDPOINT=...
 # local storage directory
 MEZCAL_STORAGE_DIR=image_cache
 # storage directory layout
@@ -86,8 +86,8 @@ Run the container:
 ```zsh
 docker run -d -p 5000:5000 \
     -v mezcal-cache:/var/cache/mezcal \
-    -e MEZCAL_JWT_TOKEN=... \
-    -e MEZCAL_REPO_BASE_URL=... \
+    -e MEZCAL_FCREPO_JWT_TOKEN=... \
+    -e MEZCAL_FCREPO_ENDPOINT=... \
     -e MEZCAL_STORAGE_DIR=/var/cache/mezcal \
     -e MEZCAL_STORAGE_LAYOUT=basic \
     docker.lib.umd.edu/mezcal:latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "filelock",
     "flask",
     "pillow~=11.0",
+    "plastron-client>=4.7.0",
     "python-dotenv",
     "requests",
     "requests-jwtauth",

--- a/src/mezcal/http.py
+++ b/src/mezcal/http.py
@@ -1,35 +1,27 @@
 import logging
-from enum import Enum
 from threading import current_thread
 
 import requests
 from codetiming import Timer
+from plastron.client import Client
 
 from mezcal.config import TIMER_LOG_FORMAT
 
 logger = logging.getLogger(__name__)
 
 
-class RepositoryAuthType(Enum):
-    NONE = 0
-    BASIC = 1
-    JWT_TOKEN = 2
-    JWT_SECRET = 3
-
-
 class OriginRepository:
-    def __init__(self, base_url: str):
-        self.base_url = base_url
+    def __init__(self, client: Client):
+        self.client = client
 
-    def get(self, repo_path: str, auth=None) -> requests.Response:
+    def get(self, repo_path: str) -> requests.Response:
         with Timer(
             name=f'request origin image {repo_path} in {current_thread().name}',
             logger=logger.info,
             text=TIMER_LOG_FORMAT
         ):
-            url = self.base_url + repo_path
-            logger.debug(f'Requesting from {url}')
-            response = requests.get(url, auth=auth, stream=True)
+            url = f'{self.client.endpoint.url}{repo_path}'
+            response = self.client.get(url, stream=True)
             if response.ok:
                 logger.debug(f'Received {response.status_code} {response.reason} response')
                 logger.debug(f'Response headers: {response.headers}')

--- a/src/mezcal/storage.py
+++ b/src/mezcal/storage.py
@@ -5,7 +5,6 @@ from hashlib import md5
 from pathlib import Path
 from struct import unpack
 from threading import current_thread
-from typing import Type
 
 from PIL import Image
 from PIL.ImageOps import exif_transpose
@@ -24,7 +23,7 @@ class DirectoryLayout(Enum):
 
 
 class LocalStorage:
-    def __init__(self, storage_dir: Path | str = '', layout: Type[DirectoryLayout] | str = DirectoryLayout.BASIC):
+    def __init__(self, storage_dir: Path | str = '', layout: DirectoryLayout | str = DirectoryLayout.BASIC):
         self.storage_dir = Path.cwd() / storage_dir
         if isinstance(layout, str):
             try:
@@ -55,8 +54,9 @@ class LocalStorage:
 
 SUPPORTED_JPEG_MODES = ('L', 'RGB', 'CMYK')
 
+
 class MezzanineFile:
-    def __init__(self, path: Path = None):
+    def __init__(self, path: Path):
         self.path = path
         self.lock_path = Path(f'{self.path.parent}.lock')
 
@@ -140,7 +140,7 @@ class MezzanineFile:
                 raise RuntimeError('Unable to remove resource')
 
 
-def convert_I16B_to_L(img: Image) -> Image:
+def convert_I16B_to_L(img: Image.Image) -> Image.Image:
     # format pattern is: big endian marker (">"), followed by
     # the total number pixels (image width * height), followed
     # by the datatype marked for "unsigned short", i.e., 2 bytes

--- a/src/mezcal/web.py
+++ b/src/mezcal/web.py
@@ -1,53 +1,65 @@
 import logging
-import os
 from collections.abc import Mapping
 from http import HTTPStatus
 from threading import current_thread
-from typing import Optional, Any
+from typing import Any
 
 from PIL import Image
 from codetiming import Timer
 from filelock import Timeout
 from flask import Flask, send_file, request, url_for, redirect, abort
+from plastron.client import Client, Endpoint
+from plastron.client.proxied import ProxiedClient
 from requests.auth import HTTPBasicAuth, AuthBase
 from requests_jwtauth import HTTPBearerAuth, JWTSecretAuth
 
 from mezcal.config import TIMER_LOG_FORMAT
-from mezcal.http import OriginRepository, NotAnImageError, RepositoryAuthType
+from mezcal.http import OriginRepository, NotAnImageError
 from mezcal.storage import LocalStorage, DirectoryLayout
 
 logging.basicConfig(level=logging.DEBUG, format='%(levelname)s:%(name)s:%(threadName)s:%(message)s')
 logging.getLogger('PIL').setLevel(logging.INFO)
 logging.getLogger('filelock').setLevel(logging.INFO)
 
+logger = logging.getLogger(__name__)
+
 LOCK_TIMEOUT = 30
 
 
-def get_authenticator(authentication_type: RepositoryAuthType, config: Mapping[str, Any]) -> Optional[AuthBase]:
-    """Return a new Requests authenticator as determined by the authentication_type parameter.
+def get_authenticator(config: Mapping[str, Any]) -> AuthBase | None:
+    if 'FCREPO_JWT_SECRET' in config:
+        return JWTSecretAuth(
+            secret=config['FCREPO_JWT_SECRET'],
+            claims={'sub': 'mezcal', 'iss': 'fcrepo', 'role': 'fedoraAdmin'},
+        )
 
-    Configuration values for the authenticators, if any, are taken from the given `config`
-    mapping. Raises a `RuntimeError` if a required key is not set in `config`."""
+    if 'FCREPO_JWT_TOKEN' in config:
+        return HTTPBearerAuth(config['FCREPO_JWT_TOKEN'])
 
+    if 'FCREPO_USERNAME' in config and 'FCREPO_PASSWORD' in config:
+        return HTTPBasicAuth(config['FCREPO_USERNAME'], config['FCREPO_PASSWORD'])
+
+    return None
+
+
+def get_client(config: Mapping[str, Any]) -> Client:
     try:
-        match authentication_type:
-            case RepositoryAuthType.NONE:
-                return None
-            case RepositoryAuthType.BASIC:
-                return HTTPBasicAuth(config['REPO_USERNAME'], config['REPO_PASSWORD'])
-            case RepositoryAuthType.JWT_TOKEN:
-                return HTTPBearerAuth(config['JWT_TOKEN'])
-            case RepositoryAuthType.JWT_SECRET:
-                return JWTSecretAuth(
-                    secret=config['JWT_SECRET'],
-                    claims={
-                        'sub': 'mezcal',
-                        'iss': 'fcrepo',
-                        'role': 'fedoraAdmin',
-                    }
-                )
+        endpoint = Endpoint(config['FCREPO_ENDPOINT'])
+        auth = get_authenticator(config)
+
+        if 'FCREPO_ORIGIN' in config:
+            return ProxiedClient(
+                endpoint=endpoint,
+                origin_endpoint=Endpoint(config['FCREPO_ORIGIN']),
+                auth=auth,
+            )
+        else:
+            return Client(
+                endpoint=endpoint,
+                auth=auth,
+            )
     except KeyError as e:
-        raise RuntimeError(f'Environment variable {e} is not set') from e
+        raise RuntimeError(f'Configuration is missing a required key: {e}')
 
 
 def create_app() -> Flask:
@@ -70,7 +82,7 @@ def create_app() -> Flask:
         storage_dir=app.config.get('STORAGE_DIR', ''),
         layout=DirectoryLayout[layout_name],
     )
-    origin_repo = OriginRepository(app.config.get('REPO_BASE_URL'))
+    origin_repo = OriginRepository(get_client(app.config))
 
     @app.route('/')
     def home():
@@ -78,11 +90,12 @@ def create_app() -> Flask:
             return '<form><label>Repository URL: <input name="url" size="120"/></label><button>Fetch</button></form>'
 
         url = request.args['url']
-        if url.startswith(origin_repo.base_url):
-            repo_path = url[len(origin_repo.base_url):]
+        endpoint = origin_repo.client.endpoint.url
+        if url.startswith(endpoint):
+            repo_path = url.removeprefix(endpoint).removeprefix('/')
             return redirect(url_for('resource', repo_path=repo_path))
         else:
-            app.logger.error(f'URL {url} does not start with {origin_repo.base_url}')
+            app.logger.error(f'URL {url} does not start with {endpoint}')
             abort(HTTPStatus.NOT_FOUND)
 
     @app.route('/images/<path:repo_path>')
@@ -97,9 +110,8 @@ def create_app() -> Flask:
                 with local_file.lock.acquire(timeout=LOCK_TIMEOUT):
                     if not local_file.exists:
                         app.logger.debug(f'No local copy exists for /{repo_path} (local file path: {local_file})')
-                        auth_type = RepositoryAuthType[os.environ.get("AUTH_TYPE", "NONE")]
                         try:
-                            response = origin_repo.get(repo_path, auth=get_authenticator(auth_type, app.config))
+                            response = origin_repo.get(f'/{repo_path}')
                             local_file.create(response.raw)
                         except NotAnImageError:
                             abort(HTTPStatus.BAD_REQUEST, description='Requested resource is not an image')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ from mezcal.web import create_app
 
 @pytest.fixture()
 def test_client(datadir, monkeypatch):
-    monkeypatch.setenv('MEZCAL_REPO_BASE_URL', 'http://example.org/repo/')
+    monkeypatch.setenv('MEZCAL_FCREPO_ENDPOINT', 'http://example.org/repo')
     monkeypatch.setenv('MEZCAL_STORAGE_DIR', str(datadir))
     flask_app = create_app()
 

--- a/tests/test_get_authenticator.py
+++ b/tests/test_get_authenticator.py
@@ -1,39 +1,31 @@
-import pytest
 from requests.auth import HTTPBasicAuth
 from requests_jwtauth import HTTPBearerAuth, JWTSecretAuth
 
-from mezcal.http import RepositoryAuthType
 from mezcal.web import get_authenticator
 
 
 def test_get_authenticator_none():
-    auth = get_authenticator(RepositoryAuthType.NONE, {})
+    auth = get_authenticator({})
     assert auth is None
 
 
 def test_get_authenticator_basic():
-    auth = get_authenticator(RepositoryAuthType.BASIC, {'REPO_USERNAME': 'foo','REPO_PASSWORD': 'bar'})
+    auth = get_authenticator({'FCREPO_USERNAME': 'foo', 'FCREPO_PASSWORD': 'bar'})
     assert isinstance(auth, HTTPBasicAuth)
     assert auth.username == 'foo'
     assert auth.password == 'bar'
 
 
 def test_get_authenticator_jwt_token():
-    auth = get_authenticator(RepositoryAuthType.JWT_TOKEN, {'JWT_TOKEN': 'token'})
+    auth = get_authenticator({'FCREPO_JWT_TOKEN': 'token'})
     assert isinstance(auth, HTTPBearerAuth)
     assert auth.token == 'token'
 
 
 def test_get_authenticator_jwt_secret():
-    auth = get_authenticator(RepositoryAuthType.JWT_SECRET, {'JWT_SECRET': 'secret'})
+    auth = get_authenticator({'FCREPO_JWT_SECRET': 'secret'})
     assert isinstance(auth, JWTSecretAuth)
     assert auth.secret == 'secret'
     assert auth.claims['sub'] == 'mezcal'
     assert auth.claims['iss'] == 'fcrepo'
     assert auth.claims['role'] == 'fedoraAdmin'
-
-
-def test_get_authenticator_missing_key():
-    with pytest.raises(RuntimeError) as e:
-        _auth = get_authenticator(RepositoryAuthType.JWT_TOKEN, {})
-        assert str(e) == "Environment variable 'JWT_TOKEN' is not set"

--- a/tests/test_get_client.py
+++ b/tests/test_get_client.py
@@ -1,0 +1,31 @@
+import pytest
+from plastron.client import Client
+from plastron.client.proxied import ProxiedClient
+
+from mezcal.web import get_client
+
+
+@pytest.mark.parametrize(
+    ('config', 'expected_class'),
+    [
+        (
+            {'FCREPO_ENDPOINT': 'https://example.com/fcrepo/rest'},
+            Client,
+        ),
+        (
+            {
+                'FCREPO_ENDPOINT': 'https://example.com/fcrepo/rest',
+                'FCREPO_ORIGIN': 'http://localhost:8080/fcrepo/rest'
+            },
+            ProxiedClient,
+        ),
+    ]
+)
+def test_get_client(config, expected_class):
+    client = get_client(config)
+    assert isinstance(client, expected_class)
+
+
+def test_get_client_missing_config():
+    with pytest.raises(RuntimeError):
+        get_client({})

--- a/tests/test_max_image_pixels.py
+++ b/tests/test_max_image_pixels.py
@@ -4,6 +4,7 @@ from mezcal.web import create_app
 
 
 def test_max_image_pixels(monkeypatch):
+    monkeypatch.setenv('MEZCAL_FCREPO_ENDPOINT', 'http://example.com/fcrepo/rest')
     monkeypatch.setenv('MEZCAL_MAX_IMAGE_PIXELS', '1024')
     app = create_app()
     assert app.config['MAX_IMAGE_PIXELS'] == 1024
@@ -11,6 +12,7 @@ def test_max_image_pixels(monkeypatch):
 
 
 def test_max_image_pixels_default(monkeypatch):
+    monkeypatch.setenv('MEZCAL_FCREPO_ENDPOINT', 'http://example.com/fcrepo/rest')
     original_max_pixels = PIL.Image.MAX_IMAGE_PIXELS
     monkeypatch.setenv('MEZCAL_MAX_IMAGE_PIXELS', '0')
     app = create_app()
@@ -19,6 +21,7 @@ def test_max_image_pixels_default(monkeypatch):
 
 
 def test_max_image_pixels_no_limit(monkeypatch):
+    monkeypatch.setenv('MEZCAL_FCREPO_ENDPOINT', 'http://example.com/fcrepo/rest')
     monkeypatch.setenv('MEZCAL_MAX_IMAGE_PIXELS', '-1')
     app = create_app()
     assert app.config['MAX_IMAGE_PIXELS'] == -1

--- a/tests/test_origin_repository.py
+++ b/tests/test_origin_repository.py
@@ -2,6 +2,7 @@ import pytest
 import requests
 
 from mezcal.http import OriginRepository, NotAnImageError
+from mezcal.web import get_client
 
 
 class MockOKResponse:
@@ -30,16 +31,19 @@ def mock_request(response):
     return _request
 
 
-def test_not_an_image(monkeypatch):
-    monkeypatch.setattr(requests, 'get', mock_request(response=NonImageResponse()))
-    repo = OriginRepository('http://example.com/repo')
+@pytest.fixture
+def repo():
+    return OriginRepository(get_client({'FCREPO_ENDPOINT': 'http://example.com/repo'}))
+
+
+def test_not_an_image(monkeypatch, repo):
+    monkeypatch.setattr(repo.client, 'get', mock_request(response=NonImageResponse()))
     with pytest.raises(NotAnImageError):
         repo.get('/foo')
 
 
-def test_image(monkeypatch):
-    monkeypatch.setattr(requests, 'get', mock_request(response=ImageResponse()))
-    repo = OriginRepository('http://example.com/repo')
+def test_image(monkeypatch, repo):
+    monkeypatch.setattr(repo.client, 'get', mock_request(response=ImageResponse()))
     response = repo.get('/foo')
     assert response.ok
     assert response.status_code == 200
@@ -47,9 +51,8 @@ def test_image(monkeypatch):
     assert response.headers['Content-Type'] == 'image/tiff'
 
 
-def test_origin_not_ok_response(monkeypatch):
+def test_origin_not_ok_response(monkeypatch, repo):
     monkeypatch.setattr(requests, 'get', mock_request(response=MockBadRequestResponse()))
-    repo = OriginRepository('http://example.com/repo')
     with pytest.raises(RuntimeError) as e:
         repo.get('/foo')
         assert str(e) == 'Unable to retrieve resource'


### PR DESCRIPTION
- borrow configuration pattern from Solrizer
- allows setting a separate `MEZCAL_FCREPO_ENDPOINT` and `MEZCAL_FCREPO_ORIGIN`
- formatting and type annotation cleanup
- updated documentation

https://umd-dit.atlassian.net/browse/LIBIIIF-217